### PR TITLE
Rework how FP is calculated (For the most part)

### DIFF
--- a/source/online/FunkinPoints.hx
+++ b/source/online/FunkinPoints.hx
@@ -10,14 +10,20 @@ class FunkinPoints {
             return 0;
 		if (notesHit <= 0)
             return 0;
-
+		//combo scaling is not a great idea due to making misses worth different amounts at different parts. it also just decimates FP if you miss at the end because its based off curent combo and not highest combo.
+		//also like the amount of fp you actually get is like really low?? i feel like it should def be rewarding a bit more especially in FC and High Accuracy situations.
+		//if you really want to keep combo scaling id suggest making it similar to beat saber. dont ask me how to do that though
 		var fp:Float = notesHit / (noteDensity / 2);
-		fp *= 1 + combo / 1000;
 		fp *= accuracy / (misses * 0.2 + 1) * (1 - noteDensity / 500);
+		
+		//Modifiers for song speed and scroll speed
 		fp *= playbackRate;
-		var songSpeedAdd = songSpeed - 3.0;
-		if (songSpeedAdd > 0)
-			fp *= 1 + songSpeedAdd;
+		var scrollbonus:Float = 0.09526 * (Math.pow((0.8 * songSpeed - 1.6), 4)); // Scales FP in a parabala manner awarding playing on really low and really high speeds. ~1.2x at 0.5 and 3.5, 1.5x at 0(who would do this to themselves) and 4
+		scrollbonus = Math.ffloor(1.5); // clamps previous bonus so people at scroll speed 5 dont start earning 4x FP
+		fp *= scrollbonus;
+		fp *= 5; // Im still undecided about this number but i do think FP should be a bit more plentiful
+		if (misses > 0)
+			fp *= 0.9; // locks 10% of FP behind a FC. Im not sure this works retroactivley like i want it to but it works enough.
 		return Math.ffloor(fp);
     }
 
@@ -29,3 +35,4 @@ class FunkinPoints {
 		return gained;
     }
 }
+// thanks to mmm salmon for helping me with the math on this 


### PR DESCRIPTION
i'm calling this a rework because the effects it has is rather drastic but also the core component of how FP is actually earned hasnt been touched (yet?)

**the issue** i (and a few others) have had with the current FP calculations is the combo scaling. 
It sounds good on paper combo scaling actually makes the way FP is earned quite unfair due to having misses later into the song count more than misses at the start

What i have done is changed it to be a bit more fair and a little bit closer to pp while also generally be more rewarding 

**the changes**
- removed combo scaling, your combo no longer affects how much FP you earn
- made the first miss count more than the rest giving a bonus for FC
- changed how the scroll speed modifier works to make it a bit more reasonable and not give basically free FP
- multiplied the total amount of FP gained to feel more rewarding

you can read through all the code comments to get an understanding of what does what and my reasoning behind it

example of the differences in FP gain using GHOST from vs camellia
old is on the left and new is on the right
![screenshot](https://github.com/user-attachments/assets/40a85f11-eddc-45ed-9395-06ff950f2bc3)


i dont really expect all of this to be put into effect and im not 100% how all the numbers are and if they need to be tweaked but at the very least i do think the combo scaling should be removed