### PR TITLE
[ENHANCEMENT] Show the Default Avatar (BF Sticker) in Profilebox

### DIFF
--- a/source/online/network/FunkinNetwork.hx
+++ b/source/online/network/FunkinNetwork.hx
@@ -262,11 +262,29 @@ class FunkinNetwork {
 		});
 
 		if (avatarResponse == null)
-			return null;
+			return getDefaultAvatar();
 
 		try {
 			var bytes = output.getBytes();
 			cacheAvatar.set(user, bytes);
+			return BitmapData.fromBytes(bytes);
+		}
+		catch (exc) {
+			trace(exc);
+			return getDefaultAvatar();
+		}
+	}
+
+	public static function getDefaultAvatar():BitmapData
+	{
+		var output = new BytesOutput();
+		var avatarResponse = FunkinNetwork.requestAPI({
+			path: 'images/bf' + FlxG.random.int(1, 2) + ".png",
+			bodyOutput: output
+		});
+
+		try {
+			var bytes = output.getBytes();
 			return BitmapData.fromBytes(bytes);
 		}
 		catch (exc) {


### PR DESCRIPTION
This PR makes it so when an avatar can't be loaded (probably because the current user doesn't have an avatar), it will use the bf stickers. This makes it similar to the actual website.