### PR TITLE
[BUGFIX] Add a fallback to peo_auth.json corruption

### DIFF
--- a/source/online/network/Auth.hx
+++ b/source/online/network/Auth.hx
@@ -27,7 +27,7 @@ class Auth {
 		try {
 			saveData = Json.parse(File.getContent(savePath));
 		} catch(e) {
-			trace("Couldn't load peo_auth.json! More info " + e);
+			trace("Couldn't load peo_auth.json! More info: " + e);
 			generateSave();
 			saveData = {
 				id: null,

--- a/source/online/network/Auth.hx
+++ b/source/online/network/Auth.hx
@@ -21,17 +21,20 @@ class Auth {
     public static function load() {
 		savePath = lime.system.System.applicationStorageDirectory + 'peo_auth.json';
 
-		if (!FileSystem.exists(savePath)) {
-			if (!FileSystem.exists(Path.directory(savePath)))
-				FileSystem.createDirectory(Path.directory(savePath));
+		if (!FileSystem.exists(savePath))
+			generateSave();
 
-			File.saveContent(savePath, Json.stringify({
-                id: null,
-                token: null
-            }));
-        }
+		try {
+			saveData = Json.parse(File.getContent(savePath));
+		} catch(e) {
+			trace("Couldn't load peo_auth.json! More info " + e);
+			generateSave();
+			saveData = {
+				id: null,
+				token: null
+			};
+		}
 
-		saveData = Json.parse(File.getContent(savePath));
         //FileSystem.deleteFile(savePath); // maybe not a good idea?
 
 		authID = saveData.id;
@@ -46,6 +49,16 @@ class Auth {
 			FlxG.save.flush();
         }
     }
+
+	public static function generateSave() {
+		if (!FileSystem.exists(Path.directory(savePath)))
+			FileSystem.createDirectory(Path.directory(savePath));
+
+		File.saveContent(savePath, Json.stringify({
+            id: null,
+            token: null
+        }));
+	}
 
     public static function save(id:String, token:String) {
 		saveData.id = authID = id;


### PR DESCRIPTION
There is a chance of people closing the game while `peo_auth.json` is being written to, corrupting the entire file and making Psych Online unplayable.

This PR makes it so there is at least a fallback when loading the game up, in case above happens.

This fixes #95 