### PR TITLE
Use hxvlc instead of hxCodec

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -116,7 +116,7 @@
 	<!--Psych stuff needed-->
 	<haxelib name="linc_luajit" if="LUA_ALLOWED" />
 	<haxelib name="SScript" if="HSCRIPT_ALLOWED" />
-	<haxelib name="hxCodec" if="VIDEOS_ALLOWED" />
+	<haxelib name="hxvlc" if="VIDEOS_ALLOWED" />
 	<haxelib name="discord_rpc" if="DISCORD_ALLOWED" />
 	<haxelib name="tjson" />
 	<haxelib name="colyseus" />

--- a/hmm.json
+++ b/hmm.json
@@ -51,11 +51,9 @@
       "version": "1.1.0"
     },
     {
-      "name": "hxCodec",
-      "type": "git",
-      "dir": null,
-      "ref": "cafc58e9046505ff93fa659339808b53faa5d6f3",
-      "url": "https://github.com/polybiusproxy/hxCodec"
+      "name": "hxvlc",
+      "type": "haxelib",
+      "version": "1.8.2"
     },
     {
       "name": "SScript",

--- a/source/backend/HxCodecWrapper.hx
+++ b/source/backend/HxCodecWrapper.hx
@@ -1,0 +1,13 @@
+package backend;
+
+/**
+ * This class ensures backwards compatibility with hxCodec.
+ */
+class VideoHandler extends hxvlc.flixel.FlxVideo
+{
+	override public function play(location:String, shouldLoop:Bool = false):Bool
+	{
+		this.load(location, shouldLoop ? ["input-repeat=65535"] : []);
+		return super.play();
+	}
+}

--- a/source/online/backend/Deflection.hx
+++ b/source/online/backend/Deflection.hx
@@ -10,6 +10,11 @@ class Deflection {
 		if (classBlacklist == null)
 			initClassBlacklist();
 
+		if(clsName == 'hxcodec.flixel.FlxVideo')
+		{
+			clsName = 'backend.HxCodecWrapper';
+		}
+
 		var cls = Type.resolveClass(clsName);
 
 		if (classBlacklist.contains(cls)) {

--- a/source/online/states/OnlineState.hx
+++ b/source/online/states/OnlineState.hx
@@ -563,8 +563,9 @@ class OnlineState extends MusicBeatState {
 						add(ass);
 						
 						
-						var video = new hxcodec.flixel.FlxVideo();
-						video.play(Paths.video('enables'));
+						var video = new hxvlc.flixel.FlxVideo();
+						video.load(Paths.video('enables'));
+						video.play();
 						video.onEndReached.add(function() {
 							video.dispose();
 

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -76,10 +76,7 @@ import sys.io.File;
 #end
 
 #if VIDEOS_ALLOWED 
-#if (hxCodec >= "3.0.0") import hxcodec.flixel.FlxVideo as VideoHandler;
-#elseif (hxCodec >= "2.6.1") import hxcodec.VideoHandler as VideoHandler;
-#elseif (hxCodec == "2.6.0") import VideoHandler;
-#else import vlc.MP4Handler as VideoHandler; #end
+import hxvlc.flixel.FlxVideo;
 #end
 
 import objects.Note.EventNote;
@@ -1503,25 +1500,15 @@ class PlayState extends MusicBeatState
 			return;
 		}
 
-		var video:VideoHandler = new VideoHandler();
-			#if (hxCodec >= "3.0.0")
-			// Recent versions
-			video.play(filepath);
-			video.onEndReached.add(function()
-			{
-				video.dispose();
-				startAndEnd();
-				return;
-			}, true);
-			#else
-			// Older versions
-			video.playVideo(filepath);
-			video.finishCallback = function()
-			{
-				startAndEnd();
-				return;
-			}
-			#end
+		var video:FlxVideo = new FlxVideo();
+		video.load(filepath);
+		video.play();
+		video.onEndReached.add(function()
+		{
+			video.dispose();
+			startAndEnd();
+			return;
+		}, true);
 		#else
 		FlxG.log.warn('Platform not supported!');
 		startAndEnd();


### PR DESCRIPTION
hxCodec is extremely fragile, so this PR replaces hxCodec with hxvlc, which is hxCodec, but way more stable.

This PR also adds backwards compatibilty to hxCodec