### PR TITLE
"Fix 0.7 Sustains"

### DIFF
--- a/source/objects/Note.hx
+++ b/source/objects/Note.hx
@@ -279,7 +279,7 @@ class Note extends FlxSprite
 				scale.y *= PlayState.daPixelZoom;
 				updateHitbox();
 			}
-			earlyHitMult = 0;
+			earlyHitMult = 0.3;
 		}
 		else if(!isSustainNote)
 		{


### PR DESCRIPTION
This PR makes it so you can hit sustain notes a little bit early, basically "fixing" sustains.
Poyo helped me with fine-tuning `earlyHitMult` to not be too generous.