### PR TITLE
fix FranksSpiritsBowling

### DIFF
--- a/source/states/stages/FranksSpiritsBowling.hx
+++ b/source/states/stages/FranksSpiritsBowling.hx
@@ -123,7 +123,9 @@ class FranksSpiritsBowling extends BaseStage {
 							tankBih.resetShit(500, 290, TankmenBG.animationNotes[i][1] < 2);
 							tankBih.scale.set(1.1, 1.1);
 							tankBih.updateHitbox();
-							tankBih.shader = tankrunShader.shader;
+							if (ClientPrefs.data.shaders) {
+								tankBih.shader = tankrunShader.shader;
+							}
 							tankmanRun.add(tankBih);
 						}
 					}


### PR DESCRIPTION
if close the shader and play "stress pico mix" , it will null object reference