### PR TITLE
fix auth

### DIFF
--- a/source/online/network/Auth.hx
+++ b/source/online/network/Auth.hx
@@ -76,6 +76,15 @@ class Auth {
 
 		if ((saveData.id == null || saveData.token == null) && FileSystem.exists(savePath))
 			FileSystem.deleteFile(savePath);
+
+		if (saveData.id == null || saveData.token == null) {
+			saveData = {
+				id: authID,
+				token: authToken,
+			}
+		}
+		File.saveContent(savePath, Json.stringify(saveData));
+		trace("Saved Auth Credentials...");
     }
 
 	public static function saveClose() {


### PR DESCRIPTION
If PsychOnline app crashed. Sometimes the game windows will disappear immediately. the "Main.onCreash()" / "Lib.application.window.onClose" cant be called, the auth data will be lost